### PR TITLE
harden(#270): supply-chain baseline (safe subset)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Estate CodeRabbit standard (#270 §3.7 — OpenSSF Scorecard Code-Review control).
+# CodeRabbit is the automated PR reviewer on these solo/small-team repos: it advises,
+# it never gates merges (request_changes_workflow: false) and it never edits code.
+# Branch protection does NOT require its approval — a solo repo stays self-mergeable.
+# "AI empfiehlt, Mensch entscheidet."
+#
+# INERT until the CodeRabbit GitHub App is installed on this repo's org (an org-admin
+# web-UI action, cannot be done from the CLI — tracked as the TQ-CODERABBIT-APP user-gate).
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Keeps GitHub Actions references current (#270 §3.3 — Dependency-Update-Tool).
+# Only the github-actions ecosystem applies: this repo ships docs and assets,
+# with no package manifest for a language-level updater to lock.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,20 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least-privilege default token (#270 §3.1 — Token-Permissions). This job only
+# reads the repo, installs deps, and runs tests/lint; no write scope needed.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Action refs SHA-pinned (#270 §3.2 — Pinned-Dependencies).
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest `main` | Yes |
+
+Only the current `main` receives security fixes.
+
+## Data Handling
+
+This repository ships documentation and assets for the Local SEO Performance Hub.
+It contains no runtime service, imports no credentials, and makes no network calls
+of its own. There is no telemetry.
+
+## Scope
+
+The security surface is limited to the repository's CI workflows and any content
+served from it. No user data is processed here.
+
+## Reporting a Vulnerability
+
+Report security issues **privately** via GitHub's private vulnerability reporting:
+the **Security** tab → **Report a vulnerability** on
+<https://github.com/neckarshore-mmps/mmp-local-seo-performance-hub/security/advisories>.
+This keeps the report confidential until a fix ships.
+
+Include what you found, how to reproduce it, and the impact.
+
+**Response time:** Best-effort — this is a solo-maintained project, not an SLA-backed service.


### PR DESCRIPTION
## Supply-chain hardening — safe subset (#270 §3)

Applies the **non-breaking** part of the [estate hardening standard](https://github.com/neckarshore-ai/neckarshore-planning/blob/main/docs/plans/2026-07-01-estate-supply-chain-hardening-standard.md) to `mmp-local-seo-performance-hub`, which had none of the systemic OpenSSF controls.

### In this PR (zero breakage risk)

| Control | Change |
|---------|--------|
| Token-Permissions | `ci.yml` top-level `permissions: contents: read` |
| Pinned-Dependencies | `ci.yml` — `checkout` v4.2.2, `setup-python` v5.3.0 SHA-pinned |
| Dependency-Update-Tool | `.github/dependabot.yml` — github-actions weekly |
| Security-Policy | `SECURITY.md` — private disclosure via GitHub advisories |
| Code-Review | `.coderabbit.yaml` — estate CodeRabbit standard (inert until App install) |

**SAST (CodeQL) is N/A** — docs/Shell only, no CodeQL-supported language.

### Deliberately left for the owner's terminal (Bob) — NOT done here

This repo has three bespoke automation workflows that a blind cross-repo edit could break, so they are flagged rather than touched:

1. **Branch protection** — 🚩 `changelog.yml` runs `git push` directly to `main`. A protected branch **would break it**. Requires a changelog redesign (PR flow) or a push exemption first — an owner decision, so branch protection is **not** applied here.
2. **`auto-pr.yml`** (`peter-evans/create-pull-request`) needs `contents: write` + `pull-requests: write`; **`ai-doc-suggestions.yml`** (`openai/openai-codereview` + `OPENAI_API_KEY`) needs `pull-requests: write`; **`changelog.yml`** needs `contents: write`. Adding explicit least-privilege blocks + SHA-pins to these is correct hardening but must be verified against a live run — especially the third-party OpenAI action.

### Settings applied via API

- **Secret-scanning push protection** → enabled (was off).

### Note

`ci.yml` is currently a green no-op (no `test.sh`, markdownlint never installed) — flagged in the estate register, out of supply-chain scope, left to the owner.

### Merge note

Opened by the cross-repo #270 sweep — **not self-merged**. Owner (Bob) or MASCHIN reviews and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrnXPqbtJxtk8WnvoUXDJU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a security policy with private vulnerability reporting guidance and clear expectations for handling security issues.
  * Improved repository safety by tightening CI permissions and pinning key automation steps.

* **Chores**
  * Added automated dependency updates for GitHub Actions.
  * Enabled configuration for automated PR review tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->